### PR TITLE
Refactored caching middleware, added limited error handling

### DIFF
--- a/test-site/server/server.js
+++ b/test-site/server/server.js
@@ -1,13 +1,16 @@
 const express = require('express');
-const { graphqlHTTP } = require('express-graphql');
+const path = require('path');
 const schema = require('./schema/schema');
-const { checkCache, graphqlSchema, writeToCache } = require('./controllers/quellController')
+const quellController = require('./controllers/quellController')
+
+// Apply user-defined schema to quell middleware
+quellController.schema = schema;
 
 const app = express();
 // const PORT = process.env.PORT || 3000;
 const PORT = 3000;
 
-const path = require('path');
+
 
 // JSON parser:
 app.use(express.json());
@@ -24,10 +27,8 @@ if (process.env.NODE_ENV === 'production') {
 
 // GraphQL route
 app.use('/graphql', 
-  checkCache, 
-  graphqlSchema,
-  writeToCache,
-  (req, res) => { res.status(200).send(res.locals.result) }
+  quellController.quell,
+  (req, res) => { res.status(200).send(res.locals.value) }
 );
 
 // catch-all endpoint handler


### PR DESCRIPTION
Collapsed three middleware functions (checking the cache, executing the GraphQL query, and writing results of the query into the cache) into a single function. Doing so simplifies the express route and allows us to pass cache or query results to a user-defined middleware to respond to client.

Added error handling:
- If a request without a query is received, an empty object is returned.
- If GraphQL query execution errors, a more specific error message is passed to the global error handler.

Refactored so that schema is applied to caching middleware in server.js rather than in controller file (since this controller file will eventually be a library, and we wouldn't expect an end-user to enter the library in order to import and set the schema).

**NOTE: as implemented, we cannot test queries from GraphiQL**
