### PR TITLE
Added client-side library code to create and parse AST, begin to build response from cache.

### DIFF
--- a/quell-client/.gitignore
+++ b/quell-client/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/quell-client/index.js
+++ b/quell-client/index.js
@@ -1,0 +1,154 @@
+
+
+const { parse } = require('graphql/language/parser');
+const { visit } = require('graphql/language/visitor');
+// const { buildASTSchema } = require('graphql/utilities/buildASTSchema');
+
+const sampleQuery = `
+{
+  countries {
+    id
+    name
+    capital
+    cities {
+      id
+      country_id
+      name
+      population
+    }
+  }
+}`
+
+
+/**
+ * ========== Create AST from Query ==========
+ */
+
+const AST = parse(sampleQuery);
+
+/**
+ * ========== Parse AST ==========
+ */
+
+const queryRoot = AST.definitions[0];
+
+if (queryRoot.operation !== 'query') {
+  console.log('Error: Quell currently only supports queries')
+}
+
+const prototype = {};
+// `visit` is a utility included in the graphql-JS library.
+visit(AST, {
+  SelectionSet(node, key, parent, path, ancestors) {
+      if(parent.kind === 'Field') {
+      
+        let depth = ancestors.length - 3;
+        let objPath = [parent.name.value];
+        
+        while (depth >= 5) {
+          let parentNodes = ancestors[depth - 1];
+          let { length } = parentNodes;
+          objPath.unshift(parentNodes[length - 1].name.value);
+          depth -= 3;
+        }
+
+        const collectFields = {};
+        for (let field of node.selections) {
+          collectFields[field.name.value] = true;
+        }
+        
+        function setProperty(path, obj, value) {
+          return path.reduce((prev, curr, index) => {
+            return (index + 1 === path.length) // if last item in path
+              ? prev[curr] = value // set value
+              : prev[curr] = prev[curr] || {}; 
+              // otherwise, if index exists, keep value or set to empty object if index does not exist
+          }, obj);
+        };
+
+        setProperty(objPath, prototype, collectFields);
+    }
+  }
+});
+
+console.log(prototype);
+
+// // Alternate way of nesting objects
+// let keys = Object.keys(prototype);
+// for (let i = 1; i < keys.length; i += 1) {
+//   prototype[keys[i - 1]][keys[i]] = prototype[keys[i]];
+// }
+// for (let i = 1; i < keys.length; i += 1) {
+//   delete prototype[keys[i]];
+// } 
+
+
+/**
+ * ========== Create and Populate Response From Cache ==========
+ */
+
+const dummyCache = {
+  'Country': ['Country-1', 'Country-2', 'Country-3', 'Country-4', 'Country-5'],
+  'City': ['City-1', 'City-2', 'City-3', 'City-4', 'City-5', 'City-6', 'City-7', 'City-8','City-9', 'City-10'],
+  'Country-1': {'id': 1, 'name': 'Andorra', 'capital': 'Andorra la Vella', 'cities': ['City-1', 'City-2']},
+  'Country-2': {'id': 2, 'name': 'Bolivia', 'capital': 'Sucre', 'cities': ['City-5', 'City-7']},
+  'Country-3': {'id': 3, 'name': 'Armenia', 'capital': 'Yerevan', 'cities': ['City-3', 'City-6']},
+  'Country-4': {'id': 4, 'name': 'American Samoa', 'capital': 'Pago Pago', 'cities': ['City-8', 'City-4']},
+  'Country-5': {'id': 5, 'name': 'Aruba', 'capital': 'Oranjestad', 'cities': ['City-9', 'City-10']},
+  'City-1': {"id": 1, "country_id": 1, "name": "El Tarter", "population": 1052},
+  'City-2': {"id": 2,"country_id": 1, "name": "La Massana", "population": 7211},
+  'City-3': {"id":3,"country_id":3,"name":"Canillo","population":3292},
+  'City-4': {"id":4,"country_id":4,"name":"Andorra la Vella","population":20430},
+  'City-5': {"id":5,"country_id":2,"name":"Jorochito","population":4013},
+  'City-6': {"id":6,"country_id":3,"name":"Tupiza","population":22233},
+  'City-7': {"id":7,"country_id":2,"name":"Puearto Pailas","population":0},
+  'City-8': {"id":8,"country_id":4,"name":"Capinota","population":5157},
+  'City-9': {"id":9,"country_id":5,"name":"Camargo","population":4715},
+  'City-10': {"id":10,"country_id":5,"name":"Villa Serrano","population":0}
+};
+
+map = { 
+  countries: 'Country',
+  country: 'Country',
+  citiesByCountryId: 'City',
+  cities: 'City'
+}
+
+
+
+
+function handleTopLevel(prototype, map, collection) {
+  let response = [];
+  
+  for (let query in prototype) {
+    collection = collection || dummyCache[map[query]];
+    for (let item of collection) {
+      response.push(buildItem(prototype[query], dummyCache[item]))
+    }
+  }
+  
+  return response;
+};
+
+
+function buildItem(prototype, item) {
+  
+  let tempObj = {};
+  
+  for (let key in prototype) {
+    if (typeof prototype[key] === 'object') {
+      let prototypeAtKey = {[key]: prototype[key]}
+      tempObj[key] = handleTopLevel(prototypeAtKey, map, item[key])
+    } else if (prototype[key]) {
+      if (item[key]) {
+        tempObj[key] = item[key];
+      } else {
+        prototype[key] = false;
+      }
+    }
+  }
+
+  return tempObj;
+}
+
+// console.log(handleTopLevel(prototype, map));

--- a/quell-client/notes.txt
+++ b/quell-client/notes.txt
@@ -1,0 +1,172 @@
+/**
+ * 
+ * countries: []
+ * country = {
+ *  name: '',
+ *  capital: '',
+ *  
+ * }
+ * 
+ * 
+ * 1. Is there a list? To know: client.get(query-country)
+ *    If nil --> break out, run full query
+ *    If [country1, country2, ... ] --> we have a least some data that could be needed
+ * 2. What fields do I need?
+ *    [name, capital]
+ * 3. Do I already have those fields?
+ *    Name? Yes, so grab data or note data
+ *    Capital? No --> added it to new query list
+ * 4. Formulate new query, asking for fields not already in cache
+ * 
+ *     
+ *  List of needed functions:
+ *  1. Parse query into AST, maps query to cache-data representation
+ *      --> query-country, country: {name, capital, cities}, city: {name, population}
+ *   1A. Add any uniqueID fields not requested by the client
+ *  2. unique key generator
+ *      --> maps uniqueId config options, so that you know, e.g., that country is concated with id to form unique ID
+ *  3. check if requested data is in the cache
+ *     Is there a list of countries?
+ *      For the first country:
+ *        is there a name?
+ *        is there a capital?
+ *        is there a list of cities?
+ *          --properties to check:  --> properties in cache: name , properties to fetch: population
+ *          For the first city:
+ *            is there a name? - yes
+ *            is there a population - yes
+ *          For the second city:
+ *            is there a name? - yes
+ *            is there a population - no
+ *          For the third city:
+ *            is there a name? - yes
+ *            
+ *          ...
+ *          For the last city:
+ *            is there a name? - yes
+ *            
+ *      For the second country?
+ *      ...
+ *      For the last country?
+ *  4. Formulate truncated query -- asking for whatever was not fully present in cache
+ *      country {
+ *        cities {
+ *          population
+ *        }
+ *      }
+ *   5. Pass that truncated query to the graphql function, let it do its work
+ *   6. Takes the truncated query's response and adds new data to the mold/skeleton
+ *   7. Cache more filled-out objects
+ *   8. Pass along the response
+ * 
+ * 
+ *  cities {
+ *    name
+ *  }
+ * 
+ *  citiesByCountryId(country_id: 2) {
+ *    name
+ *    population
+ *    language
+ *  }
+ * go look for the more general version of this query, and fire it off
+ * 
+ * 
+ *  query-country-limit:5: [0: country-1, 1: country-2, ...]
+ *  query-country-limit:10: [0: country-1, ..., 5: country-6, . . . ]
+ *  query-cities
+ *  country-1: {id, name, capital, cities}
+ *  country-2: {id, name, capital, cities}
+ *   ...
+ *  city-1: {name, population, id, country_id}
+ *  city-2
+ * ---- JUSTIN'S IDEA ----
+ *  countries: "{country-1: {"id": "1", "name": "Andorra"}, country-2: {"id": "2", "name":"Bolivia", capital:"Sucre"},...}"
+ *  
+ * 
+ *  
+ * IF ONE BIG STRING
+ * countryData = client.get('allCountries');
+ * parsed = JSON.parse(countryData)
+ * for (let item in eachItemToCheck) {
+ *   parse[item]
+ * }
+ * 
+ * SEPARATE LITTLE STRINGS
+ * for (let item in eachItemToCheck) {
+ *  parse = JSON.parse(client.get('currentCountry'))
+    parse[item];
+ * }
+ * 
+ * 
+ * 
+ * countries(limit: 10) {
+ *   name
+ *   capital
+ * }
+ * 
+ * countries(limit: 5) {
+ *   name
+ *   capital
+ *   cities 
+ * }
+ */
+
+
+ ===== ON CACHING =====
+
+
+
+{
+  country {
+    name
+    capital
+    cities {
+      name
+      population
+    }
+  }
+}
+
+Cannot yield:
+  country.name
+  country.capital
+  country.cities.name
+  country.cities.population
+Because country query returns an array, and it wouldn't be feasible to associate each country's name, capital, and cities. For example:
+  country.name = [{name: "Andorra"}, {name: "Bolivia"}, {name: "Armenia"}]
+  country.capital = [{capital: "Andorra la Vella"}, {capital: "Sucre"}, {capital: "Yerevan"}]
+Will the results always be returned in the same order?
+
+Instead, perhaps you want to store together all the fields associated with a TYPE:
+  country: {
+    query: {
+      0: country1,
+      1: country2,
+      2: country3
+    },
+    country1: {name: "Andorra", capital: "Andorra la Vella"},
+    country2: {name: "Bolivia", capital: "Sucre"},
+    country3: {name: "Armenia", capital: "Yerevan"}
+  }
+This is better, but it still doesn't guarantee order. You still need an UNIQUE IDENTIFIER for each item in the collection:
+    country-1: {id: 1, name: "Andorra", capital: "Andorra la Vella"},
+    country-2: {id: 2, name: "Bolivia", capital: "Sucre"},
+    country-3: {id: 3, name: "Armenia", capital: "Yerevan"}
+    . . . 
+    country-122: {id: 122, . . .}
+You can either guess which field(s) contain unique identifiers -- you can, for example, look for id or _id -- or you can ask the user by requiring them to pass in an id field. What if the query does not contain a unique identifier? Maybe you have to add the unique identifer to each query.
+So, for example, you might ask users to pass in a mapping of type to unique identifer:
+{
+  uniqueIds: {
+    Country: id,
+    City: _id,
+    User: email,
+    Post: (post) => post.author + post.date,
+  },
+  generalizedQueries: {
+    citiesByCountryId: cities,
+    
+  }
+}
+Then if a query comes in that does not ask for __typename or the uniqueId, you'd add it.

--- a/quell-client/package-lock.json
+++ b/quell-client/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "quell-client",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "graphql": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.3.0.tgz",
+      "integrity": "sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w=="
+    }
+  }
+}

--- a/quell-client/package.json
+++ b/quell-client/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "quell-client",
+  "version": "1.0.0",
+  "description": "A frontend GraphQL query caching library.",
+  "main": "quell.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Quell",
+  "license": "ISC",
+  "dependencies": {
+    "graphql": "^15.3.0"
+  }
+}

--- a/quell-client/quell.js
+++ b/quell-client/quell.js
@@ -1,0 +1,142 @@
+import { parse } from 'graphql/language/parser';
+import { visit } from 'graphql/language/visitor';
+
+export default class Quell {
+  constructor(query, map) {
+    this.query = query;
+    this.map = map;
+    this.AST = parse(this.query);
+    this.proto = this.parseAST(this.AST);
+  }
+
+  /**
+   * 
+   * @param {*} AST
+   */
+  parseAST(AST) {
+    const queryRoot = AST.definitions[0];
+    
+    if (queryRoot.operation !== 'query') {
+      console.log(`Error: Quell does not currently support ${queryRoot.operation} operations.`);
+    }
+
+  /**
+   * visit() -- a utility provided in the graphql-JS library-- will walk 
+   * through an AST using a depth first traversal, invoking a callback
+   * when each SelectionSet node is entered. 
+   * 
+   * More detailed documentation can be found at:
+   * https://graphql.org/graphql-js/language/#visit
+   */
+  
+  // visit() will build the prototype, declared here and returned from the function
+  const protype = {};
+  
+  visit(AST, {
+    SelectionSet(node, key, parent, path, ancestors) {
+      /**
+       * Exclude SelectionSet nodes whose parents' are not of the kind 
+       * 'Field' to exclude nodes that do not contain information about
+       *  queried fields.
+       */
+      if(parent.kind === 'Field') {
+        
+        /** GraphQL ASTs are structured such that a field's parent field
+         *  is found three three ancestors back. Hence, we subtract three. 
+        */
+        let depth = ancestors.length - 3;
+        let objPath = [parent.name.value];
+        
+        /** Loop through ancestors to gather all ancestor nodes. This array
+         * of nodes will be necessary for properly nesting each field in the
+         * prototype object.
+         */
+        while (depth >= 5) {
+          let parentNodes = ancestors[depth - 1];
+          let { length } = parentNodes;
+          objPath.unshift(parentNodes[length - 1].name.value);
+          depth -= 3;
+        }
+
+        /** Loop over the array of fields at current node, adding each to
+         *  an object that will be assigned to the prototype object at the
+         *  position determined by the above array of ancestor fields.
+         */
+        const collectFields = {};
+        for (let field of node.selections) {
+          collectFields[field.name.value] = true;
+        }
+        
+
+        /** Helper function to convert array of ancestor fields into a
+         *  path at which to assign the `collectFields` object.
+         */
+        function setProperty(path, obj, value) {
+          return path.reduce((prev, curr, index) => {
+            return (index + 1 === path.length) // if last item in path
+              ? prev[curr] = value // set value
+              : prev[curr] = prev[curr] || {}; 
+              // otherwise, if index exists, keep value or set to empty object if index does not exist
+          }, obj);
+        };
+
+        setProperty(objPath, prototype, collectFields);
+      }
+    }
+  });
+
+  return prototype;
+}
+
+parseAST() {
+  /** Helper function that loops over a collection of references,
+   *  calling another helper function -- buildItem() -- on each. Returns an
+   *  array of those collected items.
+   */
+  function buildArray(prototype = this.proto, collection) {
+    let response = [];
+    
+    for (let query in prototype) {
+      collection = collection || dummyCache[this.map[query]];
+      for (let item of collection) {
+        response.push(buildItem(prototype[query], dummyCache[item]))
+      }
+    }
+    
+    return response;
+  };
+  
+  /** Helper function that iterates through keys -- defined on passed-in
+   *  prototype object, which is always a fragment of this.proto, assigning
+   *  to tempObj the data at matching keys in passed-in item. If a key on 
+   *  the prototype has an object as its value, buildArray is
+   *   recursively called.
+   * 
+   *  If item does not have a key corresponding to prototype, that field
+   *  is toggled to false on prototype object. Data for that field will
+   *  need to be queried.
+   * 
+   */
+
+  function buildItem(prototype, item) {
+    
+    let tempObj = {};
+    
+    for (let key in prototype) {
+      if (typeof prototype[key] === 'object') {
+        let prototypeAtKey = {[key]: prototype[key]}
+        tempObj[key] = buildArray(prototypeAtKey, item[key])
+      } else if (prototype[key]) {
+        if (item[key] !== undefined) {
+          tempObj[key] = item[key];
+        } else {
+          prototype[key] = false;
+        }
+      }
+    }
+    return tempObj;
+  }
+
+  return buildArray();
+  }
+}

--- a/quell-client/schemaIntrospection.js
+++ b/quell-client/schemaIntrospection.js
@@ -1,0 +1,10 @@
+let schemaIntrospection = {"__schema":{"queryType":{"fields":[{"name":"country","type":{"kind":"OBJECT","ofType":null}},{"name":"countries","type":{"kind":"LIST","ofType":{"kind":"OBJECT","name":"Country"}}},{"name":"citiesByCountry","type":{"kind":"LIST","ofType":{"kind":"OBJECT","name":"City"}}},{"name":"cities","type":{"kind":"LIST","ofType":{"kind":"OBJECT","name":"City"}}}]}}}
+
+const listOfQueries = schemaIntrospection.__schema.queryType.fields;
+const queryObjectTypes = listOfQueries.map((query) => {
+  let name = query.name;
+  let objectType = query.type.ofType ? query.type.ofType.name : null;
+  return { name, objectType }
+});
+
+console.log(queryObjectTypes);

--- a/test-site/server/server.js
+++ b/test-site/server/server.js
@@ -1,16 +1,11 @@
 const express = require('express');
 const path = require('path');
 const schema = require('./schema/schema');
-const quellController = require('./controllers/quellController')
-
-// Apply user-defined schema to quell middleware
-quellController.schema = schema;
+const { quell } = require('./controllers/quellController')
 
 const app = express();
 // const PORT = process.env.PORT || 3000;
 const PORT = 3000;
-
-
 
 // JSON parser:
 app.use(express.json());
@@ -27,7 +22,7 @@ if (process.env.NODE_ENV === 'production') {
 
 // GraphQL route
 app.use('/graphql', 
-  quellController.quell,
+  quell(schema),
   (req, res) => { res.status(200).send(res.locals.value) }
 );
 


### PR DESCRIPTION
One change to existing code:
I refactored the server-side quellController so that the schema can be passed in as an argument.

All other changes are additions to a new folder, quell-client, the beginnings of a library for client-side GraphQL caching.
- Added quell-client folder with:
  - quell.js: initial constructor and functionality for an importable Quell object, including AST parser and function to construct query response from cache.
  - index.js: code for quell.js as originally written. It includes some test data and can serve, for now, as a reference. Should be deleted before package is finalized.
  - notes.txt: A few notes we wrote while planning these functions. May be a helpful reference, but should be deleted before package is finalized.
  - schemaIntrospection.js: a little code experiment to explore using an introspection query to get necessary query - object type map

**N.B. Functionality in the Quell class is not tested, and may need to be refactored to complete the conversion to the new class structure. We also need to consider what properties should belong to the class.