### PR TITLE
fixed bug related to queries w/o id fields; added idMap and refactored generateId

### DIFF
--- a/quell-server/src/quell.js
+++ b/quell-server/src/quell.js
@@ -506,8 +506,7 @@ class QuellCache {
 
   /**
    * generateId generates a unique ID to refer to an item in cache. Each id concatenates the object type with an
-   * id property (item.id or item._id). If no id property is present, the item is declared uncacheable.
-   * TO-DO: use fieldsMap to find a property identified as ID type and use it to identify the item.
+   * id property (user-defined key from this.idMap, item.id or item._id). If no id property is present, the item is declared uncacheable.
    * @param {String} collection - name of schema type, used to identify each cacheable object 
    * @param {Object} item - the object, including those keys that might identify it uniquely
    */
@@ -596,6 +595,12 @@ class QuellCache {
     if (referencesToCache.length > 0) this.writeToCache(queryName, referencesToCache);
   };
 
+  /**
+   * Rebuilds response from cache, using a reconstructed prototype to govern the order of fields.
+   * @param {Array} fullResponse - array of objects returned from graphql library
+   * @param {Object} AST - abstract syntax tree
+   * @param {String} queriedCollection - name of object type returned in query
+   */
   async constructResponse(fullResponse, AST, queriedCollection) {
     const rebuiltProto = this.parseAST(AST);
     const rebuiltFromCache = await this.buildFromCache(rebuiltProto, this.queryMap, queriedCollection);


### PR DESCRIPTION
**What is the problem you were trying to solve?**
- Queries without an id field were not being cached, but a query-level array of references was. When the response was rebuilt from cache, it was returning empty arrays.
- The generated cache id defaults to .id or ._id fields, but does not attempt to identify items by fields defined by user as uniquely identifying fields.


**What is your solution and why did you solve this problem the way you did?**
- Adjusted logic so that references to uncacheable items would not be pushed to array of references.
- Added additional check so that empty arrays returned from the attempt to build the response from cache are not returned. Instead, the response from the graphql library is returned.


**Provide any additional notes on testing this functionality:**
Informally tested using Postman and looking at items in Redis.


**Screenshots / gifs of working solution:**


