### PR TITLE
parseAST function refactor

### DIFF
--- a/quell-server/src/quell.js
+++ b/quell-server/src/quell.js
@@ -266,9 +266,6 @@ class QuellCache {
             isQuellable = false;
           }
         }
-        if (node.alias) {
-          isQuellable = false;
-        }
       },
       SelectionSet(node, key, parent, path, ancestors) {
         console.log('SELECTION SET');
@@ -324,6 +321,11 @@ class QuellCache {
       },
       Field: {
         enter(node) {
+          if (node.alias) {
+            console.log('node has aliases');
+            isQuellable = false;
+            return BREAK;
+          }
           // add value to stack
           stack.push(node.name.value);
           console.log('enter stack', stack);

--- a/quell-server/src/quell.js
+++ b/quell-server/src/quell.js
@@ -331,6 +331,20 @@ class QuellCache {
             }
           }
 
+          // add arguments to temp object if parent has arguments
+          if (parent.arguments) {
+            console.log('parent args -->', parent.arguments);
+            if (parent.arguments.length > 0) {
+              // loop through arguments
+              tempObject.arguments = {};
+              for(let i = 0; i < parent.arguments.length; i ++) {
+                const key = parent.arguments[i].name.value;
+                const value = parent.arguments[i].value.value;
+                tempObject.arguments[key] = value;
+              } 
+            }
+          }
+
           console.log('tempObject after for loop', tempObject);
           console.log('stack after for loop', stack);
 


### PR DESCRIPTION
**What is the problem you were trying to solve?**
parseAST function created not correct prototype object for nested queries

**What is your solution and why did you solve this problem the way you did?**
refactor parseAST function, based on depth-first visitor's algorithm 
-- add a stack to keep track of the current node visit is visiting
-- add Field callback function on entering and leaving nodes to update stack

**Provide any additional notes on testing this functionality:**
Now we are able to get correct results for nested queries, eg  {country (id: 1) { id capital cities { id, name }} cities { id name population } countries { name }}

**Screenshots / gifs of working solution:**


