### PR TITLE
Aditi/feat/modularize error

### DIFF
--- a/quell-server/package.json
+++ b/quell-server/package.json
@@ -198,6 +198,7 @@
     "prettier": "^2.8.4",
     "supertest": "^6.1.6",
     "ts-jest": "^29.3.2",
+    "ts-node": "^10.9.2",
     "typescript": "^4.9.5"
   }
 }

--- a/quell-server/sandbox.ts
+++ b/quell-server/sandbox.ts
@@ -1,0 +1,11 @@
+import { normalizeNode } from "./src/helpers/cacheNormalizer";
+
+const result = normalizeNode(
+  "User",
+  { id: 1, name: "Naruto", __typename: "User" },
+  { __type: "User", __id: "1", name: true },
+  "User",
+  { User: "User" }
+);
+
+console.log(result);

--- a/quell-server/src/helpers/cacheNormalizer.ts
+++ b/quell-server/src/helpers/cacheNormalizer.ts
@@ -1,0 +1,21 @@
+// src/helpers/cacheNormalizer.ts
+import { ResponseDataType, ProtoObjType, QueryMapType } from "../types";
+import { getCacheID } from "./cacheUtils";
+
+export function normalizeNode(
+  key: string,
+  value: any,
+  proto: ProtoObjType,
+  parentName: string,
+  map: QueryMapType
+): { cacheID: string; payload: object } {
+  const cacheID = getCacheID(proto, map);
+  const payload: Record<string, any> = {};
+
+  for (const field in value) {
+    if (field.includes("__")) continue;
+    payload[field] = value[field];
+  }
+
+  return { cacheID, payload };
+}

--- a/quell-server/src/helpers/cacheUtils.ts
+++ b/quell-server/src/helpers/cacheUtils.ts
@@ -1,0 +1,7 @@
+// src/helpers/cacheUtils.ts
+import { ProtoObjType, QueryMapType } from "../types";
+
+export function getCacheID(proto: ProtoObjType, map: QueryMapType): string {
+  const base = map[proto.__type as string] ?? proto.__type;
+  return proto.__id ? `${base}--${proto.__id}` : String(base);
+}

--- a/quell-server/src/helpers/cacheUtils.ts
+++ b/quell-server/src/helpers/cacheUtils.ts
@@ -1,7 +1,23 @@
 // src/helpers/cacheUtils.ts
 import { ProtoObjType, QueryMapType } from "../types";
+import { ServerErrorType } from "../types";
 
 export function getCacheID(proto: ProtoObjType, map: QueryMapType): string {
   const base = map[proto.__type as string] ?? proto.__type;
   return proto.__id ? `${base}--${proto.__id}` : String(base);
 }
+
+export function createServerError(
+    log: string,
+    status = 400,
+    userMessage?: string
+  ): ServerErrorType {
+    return {
+      log,
+      status,
+      message: {
+        err: userMessage ?? "An error occurred. Check server logs.",
+      },
+    };
+  }
+  

--- a/quell-server/src/quell.ts
+++ b/quell-server/src/quell.ts
@@ -215,14 +215,14 @@ export class QuellCache {
 
       return next();
     } catch (error) {
-      const err: ServerErrorType = {
-        log: `Catch block in rateLimiter middleware, ${error}`,
-        status: 500,
-        message: {
-          err: "IPRate Limiting Error. Check server log for more details.",
-        },
-      };
-      return next(err);
+        next(
+          createServerError(
+            `Catch block in rateLimiter middleware, ${error}`,
+            500,
+            "IPRate Limiting Error. Check server log for more details."
+          )
+        )
+        return;
     }
   }
 

--- a/quell-server/src/quell.ts
+++ b/quell-server/src/quell.ts
@@ -4,6 +4,7 @@ import { RedisClientType } from "redis";
 import { redisCacheMain } from "./helpers/redisConnection";
 import { getFromRedis } from "./helpers/redisHelpers";
 import { graphql, GraphQLSchema, ExecutionResult, DocumentNode } from "graphql";
+import { createServerError } from "./helpers/cacheUtils";
 
 import {
   createQueryStr,
@@ -154,14 +155,14 @@ export class QuellCache {
 
     // Return an error if no query is found on the request.
     if (!req.body.query) {
-      const err: ServerErrorType = {
-        log: "Error: no GraphQL query found on request body, inside rateLimiter",
-        status: 400,
-        message: {
-          err: "Error in rateLimiter: Bad Request. Check server log for more details.",
-        },
-      };
-      return next(err);
+      next(
+        createServerError(
+          "Error: no GraphQL query found on request body, inside rateLimiter",
+          400,
+          "Error in rateLimiter: Bad Request. Check server log for more details."
+        )
+      );
+      return;
     }
 
     try {
@@ -186,16 +187,27 @@ export class QuellCache {
       const numRequests: number = parseInt(numRequestsString, 10);
 
       // If the number of requests is greater than the IP rate limit, throw an error.
+      // if (numRequests > ipRateLimit) {
+      //   const err: ServerErrorType = {
+      //     log: `Redis cache error: Express error handler caught too many requests from this IP address (${ipAddress}): limit is: ${ipRateLimit} requests per second, inside rateLimiter`,
+      //     status: 429, // Too Many Requests
+      //     message: {
+      //       err: "Error in rateLimiter middleware. Check server log for more details.",
+      //     },
+      //   };
+      //   return next(err);
+      // }
+
       if (numRequests > ipRateLimit) {
-        const err: ServerErrorType = {
-          log: `Redis cache error: Express error handler caught too many requests from this IP address (${ipAddress}): limit is: ${ipRateLimit} requests per second, inside rateLimiter`,
-          status: 429, // Too Many Requests
-          message: {
-            err: "Error in rateLimiter middleware. Check server log for more details.",
-          },
-        };
-        return next(err);
-      }
+        next(
+          createServerError(
+            `Redis cache error: Express error handler caught too many requests from this IP address (${ipAddress}): limit is: ${ipRateLimit} requests per second, inside rateLimiter`,
+            429,
+            "Error in rateLimiter middleware. Check server log for more details."
+          )
+        );
+        return;
+      }      
 
       console.log(
         `IP ${ipAddress} made a request. Limit is: ${ipRateLimit} requests per second. Result: OK.`


### PR DESCRIPTION
**What is the problem you were trying to solve?**

The rateLimiter middleware had multiple blocks of repeated error-handling code. Each one manually constructed an error object, making the function longer, harder to read, and more difficult to update consistently.


**What is your solution and why did you solve this problem the way you did?**

I created a reusable createServerError helper func that takes a log message, status code, and frontend message, and returns a structured ServerErrorType object. This allowed me to replace error logic in rateLimiter with clean one-liners like next(createServerError(...)). It improves readability, reduces duplication, and centralizes error formatting in one place for easier future changes.



**Provide any additional notes on testing this functionality:**

The code was type-checked using npx tsc --noEmit to confirm all changes compile without errors.

**Screenshots / gifs of working solution:**

N/A
